### PR TITLE
Add hover visuals to Cookie Quest sections

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,13 +16,15 @@
 
   <main>
     <!-- Cookie Quest 1 -->
-    <section class="project-card">
+    <section class="project-card cq1">
       <script>console.log('Init project card: Cookie Quest 1');</script>
 
       <div class="project-media">
         <script>console.log('Loading images for Cookie Quest 1');</script>
         <img src="images/cookie-quest-1-screenshot.png" alt="Cookie Quest 1 screenshot 1">
         <img src="images/cookie-quest-1-screenshot2.png" alt="Cookie Quest 1 screenshot 2">
+        <img class="sprite protag" src="images/Cookiequest1ProtagSprite.png" alt="Cookie Quest 1 protagonist sprite">
+        <img class="sprite maggy" src="images/Cookiequest1MaggySprite.png" alt="Maggy sprite">
       </div>
 
       <div class="project-info">
@@ -36,7 +38,7 @@
     </section>
 
     <!-- Cookie Quest 2 -->
-    <section class="project-card">
+    <section class="project-card cq2">
       <script>console.log('Init project card: Cookie Quest 2');</script>
 
       <div class="project-media">

--- a/style.css
+++ b/style.css
@@ -44,3 +44,33 @@ a {
   font-weight: bold;
   color: #9cf;
 }
+
+/* Cookie Quest 1 sprite hover */
+.project-card.cq1 {
+  position: relative;
+  overflow: visible;
+}
+.project-card.cq1 .sprite {
+  position: absolute;
+  bottom: -100px;
+  width: 80px;
+  pointer-events: none;
+  transition: bottom 0.3s ease;
+}
+.project-card.cq1:hover .sprite {
+  bottom: calc(100% - 40px);
+}
+.project-card.cq1 .sprite.protag {
+  left: 10%;
+}
+.project-card.cq1 .sprite.maggy {
+  right: 10%;
+}
+
+/* Cookie Quest 2 glow on hover */
+.project-card.cq2 .project-media img {
+  transition: box-shadow 0.3s ease;
+}
+.project-card.cq2:hover .project-media img {
+  box-shadow: 0 0 15px 4px rgba(255, 255, 0, 0.7);
+}


### PR DESCRIPTION
## Summary
- show protagonist & Maggy sprites popping up on the Cookie Quest 1 card
- glow Cookie Quest 2 screenshot on hover

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6846333313e083208c7f67015ab1ba81