### PR TITLE
Implement hover animations and glowing effects

### DIFF
--- a/index.html
+++ b/index.html
@@ -23,6 +23,8 @@
         <script>console.log('Loading images for Cookie Quest 1');</script>
         <img src="images/cookie-quest-1-screenshot.png" alt="Cookie Quest 1 screenshot 1">
         <img src="images/cookie-quest-1-screenshot2.png" alt="Cookie Quest 1 screenshot 2">
+      </div>
+      <div class="sprite-container">
         <img class="sprite protag" src="images/Cookiequest1ProtagSprite.png" alt="Cookie Quest 1 protagonist sprite">
         <img class="sprite maggy" src="images/Cookiequest1MaggySprite.png" alt="Maggy sprite">
       </div>

--- a/style.css
+++ b/style.css
@@ -6,8 +6,16 @@ body {
   font-family: 'Roboto', sans-serif;
   line-height: 1.5;
   padding: 2rem;
-  background: linear-gradient(180deg, #222, #444);
+  background: linear-gradient(45deg, #222, #444, #222);
+  background-size: 400% 400%;
+  animation: gradientBG 20s ease infinite;
   color: #eee;
+}
+
+@keyframes gradientBG {
+  0% { background-position: 0% 50%; }
+  50% { background-position: 100% 50%; }
+  100% { background-position: 0% 50%; }
 }
 
 /* Header styling */
@@ -50,27 +58,45 @@ a {
   position: relative;
   overflow: visible;
 }
-.project-card.cq1 .sprite {
+.project-card.cq1 .sprite-container {
   position: absolute;
-  bottom: -100px;
-  width: 80px;
+  bottom: -80px;
+  left: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  gap: 30px;
   pointer-events: none;
-  transition: bottom 0.3s ease;
+  opacity: 0;
+  transition: bottom 0.3s ease, opacity 0.3s ease;
 }
-.project-card.cq1:hover .sprite {
-  bottom: calc(100% - 40px);
+.project-card.cq1:hover .sprite-container {
+  bottom: -20px;
+  opacity: 1;
 }
-.project-card.cq1 .sprite.protag {
-  left: 10%;
-}
-.project-card.cq1 .sprite.maggy {
-  right: 10%;
+.project-card.cq1 .sprite {
+  width: 80px;
 }
 
 /* Cookie Quest 2 glow on hover */
+.project-card.cq2 .project-media {
+  position: relative;
+}
 .project-card.cq2 .project-media img {
   transition: box-shadow 0.3s ease;
 }
+.project-card.cq2 .project-media::before {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(circle, rgba(255, 255, 0, 0.6) 0%, rgba(255, 255, 0, 0) 70%);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.3s ease;
+  border-radius: 6px;
+}
 .project-card.cq2:hover .project-media img {
   box-shadow: 0 0 15px 4px rgba(255, 255, 0, 0.7);
+}
+.project-card.cq2:hover .project-media::before {
+  opacity: 1;
 }


### PR DESCRIPTION
## Summary
- adjust Cookie Quest 1 markup for new sprite container
- animate background gradient
- tweak Cookie Quest 1 sprites to appear on hover only
- improve Cookie Quest 2 screenshot glow with radial background

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_684636235188832095e592c27a465b03